### PR TITLE
External config for compass

### DIFF
--- a/Gruntfile.js
+++ b/Gruntfile.js
@@ -20,7 +20,7 @@ module.exports = function (grunt) {
         copy: {
             main: {
                 files: [
-                    {expand: true, src: ['<%= srcDir %>/**'], dest: '<%= webDir %>'}
+                    {expand: true, src: ['<%= srcDir %>/**', '!<%= srcDir %>/sass/**'], dest: '<%= webDir %>'}
                 ]
             }
         },
@@ -28,9 +28,6 @@ module.exports = function (grunt) {
         clean: {
             build: {
                 src: ['<%= targetDir %>/**']
-            },
-            sass: {
-                src: ['<%= targetDir %>/sass']
             }
         },
 
@@ -184,7 +181,7 @@ module.exports = function (grunt) {
     grunt.loadNpmTasks('grunt-contrib-clean');
 
     // sub-task that copies assets to web/assets, and also cleans some things
-    grunt.registerTask('copy:assets', ['clean:build', 'copy', 'clean:sass']);
+    grunt.registerTask('copy:assets', ['clean:build', 'copy']);
 
     // the "default" task (e.g. simply "Grunt") runs tasks for development
     grunt.registerTask('default', ['copy:assets', 'jshint', 'compass:dev']);

--- a/Gruntfile.js
+++ b/Gruntfile.js
@@ -138,8 +138,7 @@ module.exports = function (grunt) {
             // the "production" build subtask (grunt compass:dist)
             dist: {
                 options: {
-                    sassDir: '<%= targetDir %>/sass',
-                    cssDir: '<%= targetDir %>/css',
+                    config: '<%= srcDir %>/../config.rb',
                     environment: 'production',
                     outputStyle: 'compressed'
                 }
@@ -147,8 +146,7 @@ module.exports = function (grunt) {
             // the "development" build subtask (grunt compass:dev)
             dev: {
                 options: {
-                    sassDir: '<%= targetDir %>/sass',
-                    cssDir: '<%= targetDir %>/css',
+                    config: '<%= srcDir %>/../config.rb',
                     outputStyle: 'expanded'
                 }
             }

--- a/assets/sass/layout.scss
+++ b/assets/sass/layout.scss
@@ -3,7 +3,7 @@
  */
 
 @import "base";
-@import "../vendor/sass-bootstrap/lib/bootstrap";
+@import "bootstrap";
 @import "event";
 @import "events";
 

--- a/config.rb
+++ b/config.rb
@@ -1,4 +1,5 @@
 # Require any additional compass plugins here.
+add_import_path "assets/vendor/sass-bootstrap/lib/"
 
 # Set this to the root of your project when deployed:
 http_path = "/"

--- a/config.rb
+++ b/config.rb
@@ -1,0 +1,25 @@
+# Require any additional compass plugins here.
+
+# Set this to the root of your project when deployed:
+http_path = "/"
+css_dir = "web/assets/css"
+# note i am using the source directory here, not the web directory
+sass_dir = "assets/sass"
+images_dir = "web/assets/img"
+javascripts_dir = "assets/js"
+
+# You can select your preferred output style here (can be overridden via the command line):
+# output_style = :expanded or :nested or :compact or :compressed
+
+# To enable relative paths to assets via compass helper functions. Uncomment:
+#relative_assets = true
+
+# To disable debugging comments that display the original location of your selectors. Uncomment:
+# line_comments = false
+
+
+# If you prefer the indented syntax, you might want to regenerate this
+# project again passing --syntax sass, or you can uncomment this:
+# preferred_syntax = :sass
+# and then run:
+# sass-convert -R --from scss --to sass sass scss && rm -rf sass && mv scss sass


### PR DESCRIPTION
hi ryan, i suggest moving compass(path)-configuration to an external config.rb file.

why?
- you can add compass libraries in there (as i did with bootstrap)
- you dont have to clean the web/sass folder anymore, as it is not copied anymore
- if you have an ide with compass support (like phpstorm) you can enable compass support and have autocomplete features.
