### PR TITLE
Assets function and fixes

### DIFF
--- a/Gruntfile.js
+++ b/Gruntfile.js
@@ -186,11 +186,11 @@ module.exports = function (grunt) {
     grunt.loadNpmTasks('grunt-contrib-clean');
 
     // sub-task that copies assets to web/assets, and also cleans some things
-    grunt.registerTask('copy:assets', ['clean:build', 'copy', 'clean:sass']);
+    grunt.registerTask('copy:assets', ['clean:build', 'copy']);
 
     // the "default" task (e.g. simply "Grunt") runs tasks for development
-    grunt.registerTask('default', ['copy:assets', 'jshint', 'compass:dev']);
+    grunt.registerTask('default', ['copy:assets', 'jshint', 'compass:dev', 'clean:sass']);
 
     // register a "production" task that sets everything up before deployment
-    grunt.registerTask('production', ['copy:assets', 'jshint', 'requirejs', 'uglify', 'compass:dist']);
+    grunt.registerTask('production', ['copy:assets', 'jshint', 'requirejs', 'uglify', 'compass:dist', 'clean:sass']);
 };

--- a/src/Yoda/EventBundle/Resources/views/_requirejs.html.twig
+++ b/src/Yoda/EventBundle/Resources/views/_requirejs.html.twig
@@ -1,7 +1,7 @@
 <script src="{{ asset('assets/vendor/requirejs/require.js') }}"></script>
 <script>
     requirejs.config({
-        baseUrl: '{{ app.request.basePath }}/assets/js'
+        baseUrl: '{{ asset('assets/js') }}'
     });
 
     /**


### PR DESCRIPTION
2 quick fixes:

1) Use the Twig `asset` function for the `baseUrl` - I don't know why I thought having a CDN path for this would mess things up, but it appears to be fine. See sha: fe37dc1e8e198f73869052a817b9cab9a998d3d5

2) Fixed the `grunt default` task, which was deleting the copied sass files before they were being used. This may be not be needed later anyways, after #3 
