### PR TITLE
Fix jshint pattern to check all directories

### DIFF
--- a/Gruntfile.js
+++ b/Gruntfile.js
@@ -111,7 +111,7 @@ module.exports = function (grunt) {
             },
             all: [
                 'Gruntfile.js',
-                '<%= appDir %>/js/{,*/}*.js'
+                '<%= appDir %>/js/**/*.js'
             ]
         },
 


### PR DESCRIPTION
The `<%= appDir %>/js/{,*/}*.js` pattern will only check up to `web/assets/js/app` directory anything inside `web/assets/js/app/modules` directory won't be checked.
